### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_VERSION="1.70.0"
-ARG DEBIAN_VERSION="bookworm"
+ARG DEBIAN_VERSION="bullseye"
 
 
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} as builder


### PR DESCRIPTION
the version mismatch between build and run stage caused problems:
```
/statuspage-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /statuspage-exporter)
/statuspage-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /statuspage-exporter)
/statuspage-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /statuspage-exporter)
```
as there is no debian12 distroless image yet, i downgraded the build stage instead.

thank you for putting this out there!